### PR TITLE
Remove the request promise when resolved/rejected

### DIFF
--- a/extension/nostr-provider.js
+++ b/extension/nostr-provider.js
@@ -59,4 +59,6 @@ window.addEventListener('message', message => {
   } else {
     window.nostr._requests[message.data.id].resolve(message.data.response)
   }
+
+  delete window.nostr._requests[message.data.id];
 })


### PR DESCRIPTION
I'm not 100% sure if the promises needs to be kept around after being resolved, but I think it's correct to clear up these resources.