### PR TITLE
FireFox: Remove the request promise when resolved/rejected

### DIFF
--- a/extension/nostr-provider.js
+++ b/extension/nostr-provider.js
@@ -55,4 +55,6 @@ window.addEventListener('message', message => {
   } else {
     window.nostr._requests[message.data.id].resolve(message.data.response)
   }
+
+  delete window.nostr._requests[message.data.id]
 })


### PR DESCRIPTION
- I'm not 100% sure if there are logic that depends on keeping the promises around after resolving/rejecting, but I think it might be correct to clear this resource when finished.

- Same as #4 but for FireFox branch.