### PR TITLE
default permissions to empty object

### DIFF
--- a/extension/common.js
+++ b/extension/common.js
@@ -74,7 +74,7 @@ export async function readPermissionLevel(host) {
 }
 
 export async function updatePermission(host, permission) {
-  var permissions = await browser.storage.local.get('permissions').permissions
+  let {permissions = {}} = await browser.storage.local.get('permissions')
   permissions[host] = {
     ...permission,
     created_at: Math.round(Date.now() / 1000)


### PR DESCRIPTION
if there are no existing permissions, updatePermissions will error when setting the host permissions. this defaults permissions to empty object (exactly like readPermissions does)

also fixes issue #3 