### PR TITLE
Added Hmac key derivation and key tweaking API

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -8,6 +8,7 @@ import {
 } from 'nostr-tools'
 import {encrypt, decrypt} from 'nostr-tools/nip04'
 import {Mutex} from 'async-mutex'
+import { hmac } from './hmac'
 
 import {
   PERMISSIONS_REQUIRED,
@@ -117,6 +118,16 @@ async function handleContentScriptMessage({type, params, host}) {
     switch (type) {
       case 'getPublicKey': {
         return getPublicKey(sk)
+      }
+      case 'getDerivedKey': {
+        const formats = [ 'SHA-256', 'SHA-512' ]
+        let { key, format } = params
+
+        if (typeof key !== 'string') return { error: { message: 'key must be a string!' }}
+        if (!formats.includes(format)) return { error: { message: 'invalid format' }}
+
+        const hmacKey = await hmac(key, sk, format)
+        return hmacKey
       }
       case 'getRelays': {
         let results = await browser.storage.local.get('relays')

--- a/extension/background.js
+++ b/extension/background.js
@@ -11,8 +11,8 @@ import {
 import {encrypt, decrypt} from 'nostr-tools/nip04'
 import {Mutex} from 'async-mutex'
 
-import { hmac } from './hmac'
-import { getTweakedKey } from './tweak'
+import { hmac } from './hmac.js'
+import { getTweakedKey } from './tweak.js'
 import { utils } from '@noble/secp256k1'
 
 import {
@@ -159,7 +159,7 @@ async function handleContentScriptMessage({type, params, host}) {
         if (!event.id) event.id = getEventHash(event)
         if (!validateEvent(event)) return {error: {message: 'invalid event'}}
 
-        event.sig = await signEvent(event, tk)
+        event.sig = signEvent(event, tk)
         return event
       }
       case 'getRelays': {

--- a/extension/common.js
+++ b/extension/common.js
@@ -7,6 +7,7 @@ export const NO_PERMISSIONS_REQUIRED = {
 export const PERMISSIONS_REQUIRED = {
   getPublicKey: 1,
   getRelays: 5,
+  getDerivedKey: 10,
   signEvent: 10,
   'nip04.encrypt': 20,
   'nip04.decrypt': 20
@@ -15,6 +16,7 @@ export const PERMISSIONS_REQUIRED = {
 const ORDERED_PERMISSIONS = [
   [1, ['getPublicKey']],
   [5, ['getRelays']],
+  [10, ['getDerivedKey']],
   [10, ['signEvent']],
   [20, ['nip04.encrypt']],
   [20, ['nip04.decrypt']]
@@ -22,6 +24,7 @@ const ORDERED_PERMISSIONS = [
 
 const PERMISSION_NAMES = {
   getPublicKey: 'read your public key',
+  getDerivedKey: 'derive keys using HMAC(inputkey, privateKey)',
   getRelays: 'read your list of preferred relays',
   signEvent: 'sign events using your private key',
   'nip04.encrypt': 'encrypt messages to peers',

--- a/extension/common.js
+++ b/extension/common.js
@@ -7,7 +7,9 @@ export const NO_PERMISSIONS_REQUIRED = {
 export const PERMISSIONS_REQUIRED = {
   getPublicKey: 1,
   getRelays: 5,
-  getDerivedKey: 10,
+  getHmacKey: 10,
+  getTweakedPub: 10,
+  signWithTweak: 10,
   signEvent: 10,
   'nip04.encrypt': 20,
   'nip04.decrypt': 20
@@ -16,7 +18,9 @@ export const PERMISSIONS_REQUIRED = {
 const ORDERED_PERMISSIONS = [
   [1, ['getPublicKey']],
   [5, ['getRelays']],
-  [10, ['getDerivedKey']],
+  [10, ['getHmacKey']],
+  [10, ['getTweakedPub']],
+  [10, ['signWithTweak']],
   [10, ['signEvent']],
   [20, ['nip04.encrypt']],
   [20, ['nip04.decrypt']]
@@ -24,7 +28,9 @@ const ORDERED_PERMISSIONS = [
 
 const PERMISSION_NAMES = {
   getPublicKey: 'read your public key',
-  getDerivedKey: 'derive keys using HMAC(inputkey, privateKey)',
+  getHmacKey: 'derive keys using HMAC(inputkey, privateKey)',
+  getTweakedPub: 'fetch a tweaked pubkey',
+  signWithTweak: 'sign with a tweaked key',
   getRelays: 'read your list of preferred relays',
   signEvent: 'sign events using your private key',
   'nip04.encrypt': 'encrypt messages to peers',

--- a/extension/common.js
+++ b/extension/common.js
@@ -8,8 +8,6 @@ export const PERMISSIONS_REQUIRED = {
   getPublicKey: 1,
   getRelays: 5,
   getHmacKey: 10,
-  getTweakedPub: 10,
-  signWithTweak: 10,
   signEvent: 10,
   'nip04.encrypt': 20,
   'nip04.decrypt': 20
@@ -19,8 +17,6 @@ const ORDERED_PERMISSIONS = [
   [1, ['getPublicKey']],
   [5, ['getRelays']],
   [10, ['getHmacKey']],
-  [10, ['getTweakedPub']],
-  [10, ['signWithTweak']],
   [10, ['signEvent']],
   [20, ['nip04.encrypt']],
   [20, ['nip04.decrypt']]
@@ -29,8 +25,6 @@ const ORDERED_PERMISSIONS = [
 const PERMISSION_NAMES = {
   getPublicKey: 'read your public key',
   getHmacKey: 'derive keys using HMAC(inputkey, privateKey)',
-  getTweakedPub: 'fetch a tweaked pubkey',
-  signWithTweak: 'sign with a tweaked key',
   getRelays: 'read your list of preferred relays',
   signEvent: 'sign events using your private key',
   'nip04.encrypt': 'encrypt messages to peers',

--- a/extension/hmac.js
+++ b/extension/hmac.js
@@ -1,0 +1,35 @@
+const crypto = globalThis.crypto
+
+const ec = new TextEncoder()
+
+export async function hmac (key, data, format = 'SHA-256') {
+  if (typeof key !== 'string')  throw TypeError('key must be a string!')
+  if (typeof data !== 'string') throw TypeError('key must be a string!')
+
+  key  = ec.encode(key)
+  data = ec.encode(data)
+
+  const cryptoKey = await importKey(key, format)
+  return crypto.subtle
+    .sign('HMAC', cryptoKey, data)
+    .then((buffer) => new Uint8Array(buffer))
+    .then((raw) => bytesToHex(raw))
+}
+
+async function importKey (key, fmt) {
+  const config = { name: 'HMAC', hash: fmt }
+  return crypto.subtle.importKey(
+    'raw', key, config, false, ['sign', 'verify']
+  )
+}
+
+function bytesToHex (bytes) {
+  const arr = []
+  for (let i = 0; i < bytes.length; i++) {
+    const hex = bytes[i]
+      .toString(16)
+      .padStart(2, '0')
+    arr.push(hex)
+  }
+  return arr.join('')
+}

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "nos2x",
   "description": "Nostr Signer Extension",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "homepage_url": "https://github.com/fiatjaf/nos2x",
   "manifest_version": 3,
   "icons": {

--- a/extension/nostr-provider.js
+++ b/extension/nostr-provider.js
@@ -1,34 +1,7 @@
 window.nostr = {
   _requests: {},
   _pubkey: null,
-
-  async getPublicKey() {
-    if (this._pubkey) return this._pubkey
-    this._pubkey = await this._call('getPublicKey', {})
-    return this._pubkey
-  },
-
-  async getDerivedKey(key, format = 'SHA-256') {
-    return this._call('getDerivedKey', { key, format })
-  },
-
-  async signEvent(event) {
-    return this._call('signEvent', {event})
-  },
-
-  async getRelays() {
-    return this._call('getRelays', {})
-  },
-
-  nip04: {
-    async encrypt(peer, plaintext) {
-      return window.nostr._call('nip04.encrypt', {peer, plaintext})
-    },
-
-    async decrypt(peer, ciphertext) {
-      return window.nostr._call('nip04.decrypt', {peer, ciphertext})
-    }
-  },
+  _tweakedPubs: new Map(),
 
   _call(type, params) {
     return new Promise((resolve, reject) => {
@@ -44,6 +17,47 @@ window.nostr = {
         '*'
       )
     })
+  },
+
+  async getPublicKey() {
+    if (this._pubkey) return this._pubkey
+    this._pubkey = await window.nostr._call('getPublicKey', {})
+    return this._pubkey
+  },
+
+  async getHmacKey(key, format = 'SHA-256') {
+    return window.nostr._call('getHmacKey', { key, format })
+  },
+
+  async getTweakedPub(tweak) {
+    const tweakedPubs = window.nostr._tweakedPubs
+    if (!tweakedPubs.has(tweak)) {
+      const pubkey = await window.nostr._call('getTweakedPub', { tweak })
+      tweakedPubs.set(tweak, pubkey)
+    }
+    return tweakedPubs.get(tweak)
+  },
+
+  async signEvent(event) {
+    return window.nostr._call('signEvent', { event })
+  },
+
+  async signWithTweak(event, tweak) {
+    return window.nostr._call('signWithTweak', { event, tweak })
+  },
+
+  async getRelays() {
+    return this._call('getRelays', {})
+  },
+
+  nip04: {
+    async encrypt(peer, plaintext) {
+      return window.nostr._call('nip04.encrypt', {peer, plaintext})
+    },
+
+    async decrypt(peer, ciphertext) {
+      return window.nostr._call('nip04.decrypt', {peer, ciphertext})
+    }
   }
 }
 

--- a/extension/nostr-provider.js
+++ b/extension/nostr-provider.js
@@ -19,31 +19,27 @@ window.nostr = {
     })
   },
 
-  async getPublicKey() {
-    if (this._pubkey) return this._pubkey
-    this._pubkey = await window.nostr._call('getPublicKey', {})
-    return this._pubkey
+  async getPublicKey(tweak) {
+    if (typeof tweak === 'string') {
+      const tweakedPubs = window.nostr._tweakedPubs
+      if (!tweakedPubs.has(tweak)) {
+        const pubkey = await window.nostr._call('getPublicKey', { tweak })
+        tweakedPubs.set(tweak, pubkey)
+      }
+      return tweakedPubs.get(tweak)
+    } else {
+      if (this._pubkey) return this._pubkey
+      this._pubkey = await window.nostr._call('getPublicKey', {})
+      return this._pubkey
+    }
   },
 
   async getHmacKey(key, format = 'SHA-256') {
     return window.nostr._call('getHmacKey', { key, format })
   },
 
-  async getTweakedPub(tweak) {
-    const tweakedPubs = window.nostr._tweakedPubs
-    if (!tweakedPubs.has(tweak)) {
-      const pubkey = await window.nostr._call('getTweakedPub', { tweak })
-      tweakedPubs.set(tweak, pubkey)
-    }
-    return tweakedPubs.get(tweak)
-  },
-
-  async signEvent(event) {
-    return window.nostr._call('signEvent', { event })
-  },
-
-  async signWithTweak(event, tweak) {
-    return window.nostr._call('signWithTweak', { event, tweak })
+  async signEvent(event, tweak) {
+    return window.nostr._call('signEvent', { event, tweak })
   },
 
   async getRelays() {

--- a/extension/nostr-provider.js
+++ b/extension/nostr-provider.js
@@ -8,6 +8,10 @@ window.nostr = {
     return this._pubkey
   },
 
+  async getDerivedKey(key, format = 'SHA-256') {
+    return this._call('getDerivedKey', { key, format })
+  },
+
   async signEvent(event) {
     return this._call('signEvent', {event})
   },

--- a/extension/tweak.js
+++ b/extension/tweak.js
@@ -1,0 +1,56 @@
+/* global BigInt */
+
+import { utils, Point, CURVE } from '@noble/secp256k1'
+import { hmac } from './hmac.js'
+
+export async function getTweakedKey(prvkey, path) {
+  const tweak = await hmac(path, prvkey)
+  return privateTweak(prvkey, tweak)
+}
+
+function privateTweak(prvkey, tweak) {
+  if (!(
+    prvkey instanceof Uint8Array &&
+    tweak instanceof Uint8Array
+  )) { throw new Error('Invalid input!') }
+
+  const keynum = bytesToBig(prvkey)
+  const twknum = bytesToBig(tweak)
+
+  let newnum = utils.mod(keynum * twknum, CURVE.n)
+
+  if (hasOddY(newnum)) {
+    // If key has an odd Y value,
+    // perform negate operation.
+    newnum = CURVE.n - newnum
+  }
+
+  if (!utils.isValidPrivateKey(newnum)) {
+    const increment = bigToBytes(newnum + 1n)
+    return bigToBytes(increment, tweak)
+  }
+
+  return bigToBytes(newnum)
+}
+
+function hasOddY(prvkey) {
+  return !Point.fromPrivateKey(prvkey).hasEvenY
+}
+
+function bytesToBig (bytes) {
+  let num = 0n, i
+  for (i = bytes.length - 1; i >= 0; i--) {
+    num = (num * 256n) + BigInt(bytes[i])
+  }
+  return BigInt(num)
+}
+
+function bigToBytes (big) {
+  const bytes = []
+  while (big > 0n) {
+    const byte = big & 0xffn
+    bytes.push(Number(byte))
+    big = (big - byte) / 256n
+  }
+  return Uint8Array.from(bytes)
+}

--- a/extension/tweak.js
+++ b/extension/tweak.js
@@ -4,6 +4,9 @@ import { utils, Point, CURVE } from '@noble/secp256k1'
 import { hmac } from './hmac.js'
 
 export async function getTweakedKey(prvkey, path) {
+  if (typeof prvkey === 'string') {
+    prvkey = utils.hexToBytes(prvkey)
+  }
   const tweak = await hmac(path, prvkey)
   return privateTweak(prvkey, tweak)
 }
@@ -15,9 +18,9 @@ function privateTweak(prvkey, tweak) {
   )) { throw new Error('Invalid input!') }
 
   const keynum = bytesToBig(prvkey)
-  const twknum = bytesToBig(tweak)
+  const twknum = utils.mod(bytesToBig(tweak), CURVE.n)
 
-  let newnum = utils.mod(keynum * twknum, CURVE.n)
+  let newnum = utils.mod(keynum + twknum, CURVE.n)
 
   if (hasOddY(newnum)) {
     // If key has an odd Y value,
@@ -25,19 +28,26 @@ function privateTweak(prvkey, tweak) {
     newnum = CURVE.n - newnum
   }
 
-  if (!utils.isValidPrivateKey(newnum)) {
+  if (!isValidKey(newnum)) {
     const increment = bigToBytes(newnum + 1n)
-    return bigToBytes(increment, tweak)
+    return privateTweak(increment, tweak)
   }
 
   return bigToBytes(newnum)
 }
 
-function hasOddY(prvkey) {
-  return !Point.fromPrivateKey(prvkey).hasEvenY
+function hasOddY(num) {
+  const prvkey = bigToBytes(num)
+  return !Point.fromPrivateKey(prvkey).hasEvenY()
 }
 
-function bytesToBig (bytes) {
+function isValidKey(num) {
+  const prvkey = bigToBytes(num)
+  return utils.isValidPrivateKey(prvkey)
+}
+
+export function bytesToBig (bytes, rev = true) {
+  if (rev) bytes.reverse()
   let num = 0n, i
   for (i = bytes.length - 1; i >= 0; i--) {
     num = (num * 256n) + BigInt(bytes[i])
@@ -45,12 +55,13 @@ function bytesToBig (bytes) {
   return BigInt(num)
 }
 
-function bigToBytes (big) {
+export function bigToBytes (big, rev = true) {
   const bytes = []
   while (big > 0n) {
     const byte = big & 0xffn
     bytes.push(Number(byte))
     big = (big - byte) / 256n
   }
+  if (rev) bytes.reverse()
   return Uint8Array.from(bytes)
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "@noble/secp256k1": "^1.7.1",
     "async-mutex": "^0.3.2",
     "esbuild": "^0.14.11",
     "eslint": "^8.6.0",
@@ -18,5 +19,8 @@
     "build": "./build.js prod",
     "watch": "ag -l --js | entr ./build.js",
     "package": "./build.js prod; cd extension; zip -r archive *; cd ..; mv extension/archive.zip ./nos2x.zip"
+  },
+  "devDependencies": {
+    "tape": "^5.6.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,8 +19,5 @@
     "build": "./build.js prod",
     "watch": "ag -l --js | entr ./build.js",
     "package": "./build.js prod; cd extension; zip -r archive *; cd ..; mv extension/archive.zip ./nos2x.zip"
-  },
-  "devDependencies": {
-    "tape": "^5.6.3"
   }
 }

--- a/test/test.html
+++ b/test/test.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Test Suite</title>
+</head>
+<body>
+  <script src="https://unpkg.com/@cmdcode/crypto-utils@1.4.3"></script>
+  <script type="module">
+    setTimeout(async () => {
+      const { getPublicKey, getHmacKey, signEvent, getTweakedPub, signWithTweak } = window.nostr
+      const { Noble, Field, Point, Hash, Signer } = window.cryptoUtils
+
+      const ec = new TextEncoder()
+      const hexToBytes = Noble.utils.hexToBytes
+      const bytesToHex = Noble.utils.bytesToHex
+
+      const event = {
+        kind: 1,
+        created_at: Math.floor(Date.now() / 1000),
+        content: 'this is a test!',
+        tags: []
+      }
+
+      const masterPrv     = '69cf4ed2fdea041bb2081deb9a06586bddda23ab807d7f0dce11a3067b3af5d6'
+      const tweak         = '/0/0/0'
+
+      const tweakHash     = await getHmacKey(tweak)
+      const checkHash     = await Hash.hmac256(ec.encode(tweak), hexToBytes(masterPrv))
+      console.log('getHmacKey check:', tweakHash === bytesToHex(checkHash))
+      
+      const masterPub     = await getPublicKey()
+      const masterField   = new Field(hexToBytes(masterPrv))
+      const masterPoint   = masterField.point
+      const chkMasterPub  = bytesToHex(masterPoint.rawX.slice(1))
+      console.log('Master pub check:', masterPub === chkMasterPub)
+
+      const signer        = new Signer(masterPrv)
+      const signedEvent   = await signEvent(event)
+      const signerCheck   = await signer.verify(signedEvent.id, signedEvent.sig)
+      console.log('Base signature check:', signerCheck)
+
+      const tweakedPub    = await getTweakedPub(tweak)
+      const { id, pubkey, sig } = await signWithTweak(event, tweak)
+      console.log('getTweakedPub check:', pubkey === tweakedPub)
+
+      const tweakedPoint  = masterPoint.add(tweakHash)
+      const chkTweakedPub = bytesToHex(tweakedPoint.rawX.slice(1))
+      console.log('Tweaked pub check:', tweakedPub === chkTweakedPub)
+
+      const tweakField  = masterField.add(tweakHash)
+      const tweakSigner = new Signer(tweakField)
+      const twkSigCheck = await tweakSigner.verify(id, sig)
+      console.log('Tweaked signature check:', twkSigCheck)
+    }, 1000)
+  </script>
+</body>
+</html>

--- a/test/test.html
+++ b/test/test.html
@@ -24,32 +24,40 @@
         tags: []
       }
 
+      // Set the private key and tweak to use for testing.
       const masterPrv     = '69cf4ed2fdea041bb2081deb9a06586bddda23ab807d7f0dce11a3067b3af5d6'
       const tweak         = '/0/0/0'
 
+      // Verify that getHmacKey(tweak) returns the correct result.
       const tweakHash     = await getHmacKey(tweak)
       const checkHash     = await Hash.hmac256(ec.encode(tweak), hexToBytes(masterPrv))
       console.log('getHmacKey check:', tweakHash === bytesToHex(checkHash))
       
+      // Verify that getPublicKey() returns the correct result.
       const masterPub     = await getPublicKey()
       const masterField   = new Field(hexToBytes(masterPrv))
       const masterPoint   = masterField.point
       const chkMasterPub  = bytesToHex(masterPoint.rawX.slice(1))
       console.log('Master pub check:', masterPub === chkMasterPub)
 
+      // Verify that signEvent() returns the correct result.
       const signer        = new Signer(masterPrv)
       const signedEvent   = await signEvent(event)
       const signerCheck   = await signer.verify(signedEvent.id, signedEvent.sig)
       console.log('Base signature check:', signerCheck)
 
-      const tweakedPub    = await getTweakedPub(tweak)
-      const { id, pubkey, sig } = await signWithTweak(event, tweak)
+      // Verify that getPublicKey(tweak) returns the correct result.
+      const tweakedPub    = await getPublicKey(tweak)
+      const { id, pubkey, sig } = await signEvent(event, tweak)
       console.log('getTweakedPub check:', pubkey === tweakedPub)
 
+      // Verify that both getPublicKey(tweak) and signEvent(tweak)
+      // return the same pubkey as a result.
       const tweakedPoint  = masterPoint.add(tweakHash)
       const chkTweakedPub = bytesToHex(tweakedPoint.rawX.slice(1))
       console.log('Tweaked pub check:', tweakedPub === chkTweakedPub)
 
+      // Verify that signEvent(tweak) returns the correct result.
       const tweakField  = masterField.add(tweakHash)
       const tweakSigner = new Signer(tweakField)
       const twkSigCheck = await tweakSigner.verify(id, sig)

--- a/yarn.lock
+++ b/yarn.lock
@@ -46,6 +46,11 @@
   resolved "https://registry.yarnpkg.com/@noble/secp256k1/-/secp256k1-1.7.0.tgz#d15357f7c227e751d90aa06b05a0e5cf993ba8c1"
   integrity sha512-kbacwGSsH/CTout0ZnZWxnW1B+jH/7r/WAAKLBtrRJ/+CUH7lgmQzl3GTrQua3SGKWNSDsS6lmjnDpIJ5Dxyaw==
 
+"@noble/secp256k1@^1.7.1":
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/@noble/secp256k1/-/secp256k1-1.7.1.tgz#b251c70f824ce3ca7f8dc3df08d58f005cc0507c"
+  integrity sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==
+
 "@scure/base@^1.1.1", "@scure/base@~1.1.0":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.1.1.tgz#ebb651ee52ff84f420097055f4bf46cfba403938"
@@ -121,6 +126,16 @@ array-includes@^3.1.3, array-includes@^3.1.4:
     get-intrinsic "^1.1.1"
     is-string "^1.0.7"
 
+array.prototype.every@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/array.prototype.every/-/array.prototype.every-1.1.4.tgz#2762daecd9cec87cb63f3ca6be576817074a684e"
+  integrity sha512-Aui35iRZk1HHLRAyF7QP0KAnOnduaQ6fo6k1NVWfRc0xTs2AZ70ytlXvOmkC6Di4JmUs2Wv3DYzGtCQFSk5uGg==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    es-abstract "^1.20.4"
+    is-string "^1.0.7"
+
 array.prototype.flatmap@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/array.prototype.flatmap/-/array.prototype.flatmap-1.2.5.tgz#908dc82d8a406930fdf38598d51e7411d18d4446"
@@ -136,6 +151,11 @@ async-mutex@^0.3.2:
   integrity sha512-HuTK7E7MT7jZEh1P9GtRW9+aTWiDWWi9InbZ5hjxrnRa39KS4BW04+xLBhYNS2aXhHUIKZSw3gj4Pn1pj+qGAA==
   dependencies:
     tslib "^2.3.1"
+
+available-typed-arrays@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
+  integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
 
 balanced-match@^1.0.0:
   version "1.0.2"
@@ -204,6 +224,29 @@ debug@^4.1.1, debug@^4.3.2:
   dependencies:
     ms "2.1.2"
 
+deep-equal@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-2.2.0.tgz#5caeace9c781028b9ff459f33b779346637c43e6"
+  integrity sha512-RdpzE0Hv4lhowpIUKKMJfeH6C1pXdtT1/it80ubgWqwI3qpuxUBpC1S4hnHg+zjnuOoDkzUtUCEEkG+XG5l3Mw==
+  dependencies:
+    call-bind "^1.0.2"
+    es-get-iterator "^1.1.2"
+    get-intrinsic "^1.1.3"
+    is-arguments "^1.1.1"
+    is-array-buffer "^3.0.1"
+    is-date-object "^1.0.5"
+    is-regex "^1.1.4"
+    is-shared-array-buffer "^1.0.2"
+    isarray "^2.0.5"
+    object-is "^1.1.5"
+    object-keys "^1.1.1"
+    object.assign "^4.1.4"
+    regexp.prototype.flags "^1.4.3"
+    side-channel "^1.0.4"
+    which-boxed-primitive "^1.0.2"
+    which-collection "^1.0.1"
+    which-typed-array "^1.1.9"
+
 deep-is@^0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
@@ -215,6 +258,19 @@ define-properties@^1.1.3:
   integrity sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==
   dependencies:
     object-keys "^1.0.12"
+
+define-properties@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.4.tgz#0b14d7bd7fbeb2f3572c3a7eda80ea5d57fb05b1"
+  integrity sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==
+  dependencies:
+    has-property-descriptors "^1.0.0"
+    object-keys "^1.1.1"
+
+defined@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/defined/-/defined-1.0.1.tgz#c0b9db27bfaffd95d6f61399419b893df0f91ebf"
+  integrity sha512-hsBd2qSVCRE+5PmNdHt1uzyrFu5d3RwmFDKzyNZMFq/EwDNJF7Ee5+D5oEKF0hU6LhtoUF1macFvOe4AskQC1Q==
 
 doctrine@^2.1.0:
   version "2.1.0"
@@ -229,6 +285,13 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
+
+dotignore@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/dotignore/-/dotignore-0.1.2.tgz#f942f2200d28c3a76fbdd6f0ee9f3257c8a2e905"
+  integrity sha512-UGGGWfSauusaVJC+8fgV+NVvBXkCTmVv7sk6nojDZZvuOUNGUy0Zk4UpHQD6EDjS0jpBwcACvH4eofvyzBcRDw==
+  dependencies:
+    minimatch "^3.0.4"
 
 enquirer@^2.3.5:
   version "2.3.6"
@@ -262,6 +325,69 @@ es-abstract@^1.19.0, es-abstract@^1.19.1:
     string.prototype.trimend "^1.0.4"
     string.prototype.trimstart "^1.0.4"
     unbox-primitive "^1.0.1"
+
+es-abstract@^1.20.4:
+  version "1.21.1"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.21.1.tgz#e6105a099967c08377830a0c9cb589d570dd86c6"
+  integrity sha512-QudMsPOz86xYz/1dG1OuGBKOELjCh99IIWHLzy5znUB6j8xG2yMA7bfTV86VSqKF+Y/H08vQPR+9jyXpuC6hfg==
+  dependencies:
+    available-typed-arrays "^1.0.5"
+    call-bind "^1.0.2"
+    es-set-tostringtag "^2.0.1"
+    es-to-primitive "^1.2.1"
+    function-bind "^1.1.1"
+    function.prototype.name "^1.1.5"
+    get-intrinsic "^1.1.3"
+    get-symbol-description "^1.0.0"
+    globalthis "^1.0.3"
+    gopd "^1.0.1"
+    has "^1.0.3"
+    has-property-descriptors "^1.0.0"
+    has-proto "^1.0.1"
+    has-symbols "^1.0.3"
+    internal-slot "^1.0.4"
+    is-array-buffer "^3.0.1"
+    is-callable "^1.2.7"
+    is-negative-zero "^2.0.2"
+    is-regex "^1.1.4"
+    is-shared-array-buffer "^1.0.2"
+    is-string "^1.0.7"
+    is-typed-array "^1.1.10"
+    is-weakref "^1.0.2"
+    object-inspect "^1.12.2"
+    object-keys "^1.1.1"
+    object.assign "^4.1.4"
+    regexp.prototype.flags "^1.4.3"
+    safe-regex-test "^1.0.0"
+    string.prototype.trimend "^1.0.6"
+    string.prototype.trimstart "^1.0.6"
+    typed-array-length "^1.0.4"
+    unbox-primitive "^1.0.2"
+    which-typed-array "^1.1.9"
+
+es-get-iterator@^1.1.2:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/es-get-iterator/-/es-get-iterator-1.1.3.tgz#3ef87523c5d464d41084b2c3c9c214f1199763d6"
+  integrity sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==
+  dependencies:
+    call-bind "^1.0.2"
+    get-intrinsic "^1.1.3"
+    has-symbols "^1.0.3"
+    is-arguments "^1.1.1"
+    is-map "^2.0.2"
+    is-set "^2.0.2"
+    is-string "^1.0.7"
+    isarray "^2.0.5"
+    stop-iteration-iterator "^1.0.0"
+
+es-set-tostringtag@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/es-set-tostringtag/-/es-set-tostringtag-2.0.1.tgz#338d502f6f674301d710b80c8592de8a15f09cd8"
+  integrity sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==
+  dependencies:
+    get-intrinsic "^1.1.3"
+    has "^1.0.3"
+    has-tostringtag "^1.0.0"
 
 es-to-primitive@^1.2.1:
   version "1.2.1"
@@ -565,6 +691,13 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.4.tgz#28d9969ea90661b5134259f312ab6aa7929ac5e2"
   integrity sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==
 
+for-each@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
+  integrity sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==
+  dependencies:
+    is-callable "^1.1.3"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -575,10 +708,25 @@ function-bind@^1.1.1:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
+function.prototype.name@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/function.prototype.name/-/function.prototype.name-1.1.5.tgz#cce0505fe1ffb80503e6f9e46cc64e46a12a9621"
+  integrity sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+    es-abstract "^1.19.0"
+    functions-have-names "^1.2.2"
+
 functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
+
+functions-have-names@^1.2.2:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.3.tgz#0404fe4ee2ba2f607f0e0ec3c80bae994133b834"
+  integrity sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==
 
 get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1:
   version "1.1.1"
@@ -588,6 +736,20 @@ get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1:
     function-bind "^1.1.1"
     has "^1.0.3"
     has-symbols "^1.0.1"
+
+get-intrinsic@^1.1.3:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.2.0.tgz#7ad1dc0535f3a2904bba075772763e5051f6d05f"
+  integrity sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==
+  dependencies:
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    has-symbols "^1.0.3"
+
+get-package-type@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/get-package-type/-/get-package-type-0.1.0.tgz#8de2d803cff44df3bc6c456e6668b36c3926e11a"
+  integrity sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==
 
 get-symbol-description@^1.0.0:
   version "1.0.0"
@@ -616,6 +778,18 @@ glob@^7.1.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+glob@^7.2.3:
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
+  integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.1.1"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
 globals@^13.6.0, globals@^13.9.0:
   version "13.12.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-13.12.0.tgz#4d733760304230a0082ed96e21e5c565f898089e"
@@ -623,20 +797,64 @@ globals@^13.6.0, globals@^13.9.0:
   dependencies:
     type-fest "^0.20.2"
 
+globalthis@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/globalthis/-/globalthis-1.0.3.tgz#5852882a52b80dc301b0660273e1ed082f0b6ccf"
+  integrity sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==
+  dependencies:
+    define-properties "^1.1.3"
+
+gopd@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.0.1.tgz#29ff76de69dac7489b7c0918a5788e56477c332c"
+  integrity sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==
+  dependencies:
+    get-intrinsic "^1.1.3"
+
 has-bigints@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.1.tgz#64fe6acb020673e3b78db035a5af69aa9d07b113"
   integrity sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==
+
+has-bigints@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.2.tgz#0871bd3e3d51626f6ca0966668ba35d5602d6eaa"
+  integrity sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==
+
+has-dynamic-import@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/has-dynamic-import/-/has-dynamic-import-2.0.1.tgz#9bca87846aa264f2ad224fcd014946f5e5182f52"
+  integrity sha512-X3fbtsZmwb6W7fJGR9o7x65fZoodygCrZ3TVycvghP62yYQfS0t4RS0Qcz+j5tQYUKeSWS09tHkWW6WhFV3XhQ==
+  dependencies:
+    call-bind "^1.0.2"
+    get-intrinsic "^1.1.1"
 
 has-flag@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
 
+has-property-descriptors@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz#610708600606d36961ed04c196193b6a607fa861"
+  integrity sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==
+  dependencies:
+    get-intrinsic "^1.1.1"
+
+has-proto@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/has-proto/-/has-proto-1.0.1.tgz#1885c1305538958aff469fef37937c22795408e0"
+  integrity sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==
+
 has-symbols@^1.0.1, has-symbols@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.2.tgz#165d3070c00309752a1236a479331e3ac56f1423"
   integrity sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==
+
+has-symbols@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.3.tgz#bb7b2c4349251dce87b125f7bdf874aa7c8b39f8"
+  integrity sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==
 
 has-tostringtag@^1.0.0:
   version "1.0.0"
@@ -678,7 +896,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2:
+inherits@2, inherits@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -691,6 +909,32 @@ internal-slot@^1.0.3:
     get-intrinsic "^1.1.0"
     has "^1.0.3"
     side-channel "^1.0.4"
+
+internal-slot@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/internal-slot/-/internal-slot-1.0.4.tgz#8551e7baf74a7a6ba5f749cfb16aa60722f0d6f3"
+  integrity sha512-tA8URYccNzMo94s5MQZgH8NB/XTa6HsOo0MLfXTKKEnHVVdegzaQoFZ7Jp44bdvLvY2waT5dc+j5ICEswhi7UQ==
+  dependencies:
+    get-intrinsic "^1.1.3"
+    has "^1.0.3"
+    side-channel "^1.0.4"
+
+is-arguments@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.1.1.tgz#15b3f88fda01f2a97fec84ca761a560f123efa9b"
+  integrity sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==
+  dependencies:
+    call-bind "^1.0.2"
+    has-tostringtag "^1.0.0"
+
+is-array-buffer@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/is-array-buffer/-/is-array-buffer-3.0.1.tgz#deb1db4fcae48308d54ef2442706c0393997052a"
+  integrity sha512-ASfLknmY8Xa2XtB4wmbz13Wu202baeA18cJBCeCy0wXUHZF0IPyVEXqKEcd+t2fNSLLL1vC6k7lxZEojNbISXQ==
+  dependencies:
+    call-bind "^1.0.2"
+    get-intrinsic "^1.1.3"
+    is-typed-array "^1.1.10"
 
 is-bigint@^1.0.1:
   version "1.0.4"
@@ -707,6 +951,11 @@ is-boolean-object@^1.1.0:
     call-bind "^1.0.2"
     has-tostringtag "^1.0.0"
 
+is-callable@^1.1.3, is-callable@^1.2.7:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.7.tgz#3bc2a85ea742d9e36205dcacdd72ca1fdc51b055"
+  integrity sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==
+
 is-callable@^1.1.4, is-callable@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.4.tgz#47301d58dd0259407865547853df6d61fe471945"
@@ -719,7 +968,14 @@ is-core-module@^2.2.0:
   dependencies:
     has "^1.0.3"
 
-is-date-object@^1.0.1:
+is-core-module@^2.9.0:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.11.0.tgz#ad4cb3e3863e814523c96f3f58d26cc570ff0144"
+  integrity sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==
+  dependencies:
+    has "^1.0.3"
+
+is-date-object@^1.0.1, is-date-object@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.5.tgz#0841d5536e724c25597bf6ea62e1bd38298df31f"
   integrity sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==
@@ -738,7 +994,12 @@ is-glob@^4.0.0, is-glob@^4.0.3:
   dependencies:
     is-extglob "^2.1.1"
 
-is-negative-zero@^2.0.1:
+is-map@^2.0.1, is-map@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/is-map/-/is-map-2.0.2.tgz#00922db8c9bf73e81b7a335827bc2a43f2b91127"
+  integrity sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==
+
+is-negative-zero@^2.0.1, is-negative-zero@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.2.tgz#7bf6f03a28003b8b3965de3ac26f664d765f3150"
   integrity sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==
@@ -758,10 +1019,22 @@ is-regex@^1.1.4:
     call-bind "^1.0.2"
     has-tostringtag "^1.0.0"
 
+is-set@^2.0.1, is-set@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/is-set/-/is-set-2.0.2.tgz#90755fa4c2562dc1c5d4024760d6119b94ca18ec"
+  integrity sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==
+
 is-shared-array-buffer@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz#97b0c85fbdacb59c9c446fe653b82cf2b5b7cfe6"
   integrity sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==
+
+is-shared-array-buffer@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz#8f259c573b60b6a32d4058a1a07430c0a7344c79"
+  integrity sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==
+  dependencies:
+    call-bind "^1.0.2"
 
 is-string@^1.0.5, is-string@^1.0.7:
   version "1.0.7"
@@ -777,12 +1050,41 @@ is-symbol@^1.0.2, is-symbol@^1.0.3:
   dependencies:
     has-symbols "^1.0.2"
 
-is-weakref@^1.0.1:
+is-typed-array@^1.1.10, is-typed-array@^1.1.9:
+  version "1.1.10"
+  resolved "https://registry.yarnpkg.com/is-typed-array/-/is-typed-array-1.1.10.tgz#36a5b5cb4189b575d1a3e4b08536bfb485801e3f"
+  integrity sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==
+  dependencies:
+    available-typed-arrays "^1.0.5"
+    call-bind "^1.0.2"
+    for-each "^0.3.3"
+    gopd "^1.0.1"
+    has-tostringtag "^1.0.0"
+
+is-weakmap@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is-weakmap/-/is-weakmap-2.0.1.tgz#5008b59bdc43b698201d18f62b37b2ca243e8cf2"
+  integrity sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA==
+
+is-weakref@^1.0.1, is-weakref@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-weakref/-/is-weakref-1.0.2.tgz#9529f383a9338205e89765e0392efc2f100f06f2"
   integrity sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==
   dependencies:
     call-bind "^1.0.2"
+
+is-weakset@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/is-weakset/-/is-weakset-2.0.2.tgz#4569d67a747a1ce5a994dfd4ef6dcea76e7c0a1d"
+  integrity sha512-t2yVvttHkQktwnNNmBQ98AhENLdPUTDTE21uPqAQ0ARwQfGeQKRVS0NNurH7bTf7RrvcVn1OOge45CnBeHCSmg==
+  dependencies:
+    call-bind "^1.0.2"
+    get-intrinsic "^1.1.1"
+
+isarray@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.5.tgz#8af1e4c1221244cc62459faf38940d4e644a5723"
+  integrity sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -853,6 +1155,18 @@ minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
+minimatch@^3.1.1:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
+  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
+  dependencies:
+    brace-expansion "^1.1.7"
+
+minimist@^1.2.7:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.7.tgz#daa1c4d91f507390437c6a8bc01078e7000c4d18"
+  integrity sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==
+
 ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
@@ -884,6 +1198,19 @@ object-inspect@^1.11.0, object-inspect@^1.9.0:
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.0.tgz#6e2c120e868fd1fd18cb4f18c31741d0d6e776f0"
   integrity sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==
 
+object-inspect@^1.12.2, object-inspect@^1.12.3:
+  version "1.12.3"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.3.tgz#ba62dffd67ee256c8c086dfae69e016cd1f198b9"
+  integrity sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==
+
+object-is@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.1.5.tgz#b9deeaa5fc7f1846a0faecdceec138e5778f53ac"
+  integrity sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+
 object-keys@^1.0.12, object-keys@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
@@ -897,6 +1224,16 @@ object.assign@^4.1.2:
     call-bind "^1.0.0"
     define-properties "^1.1.3"
     has-symbols "^1.0.1"
+    object-keys "^1.1.1"
+
+object.assign@^4.1.4:
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.4.tgz#9673c7c7c351ab8c4d0b516f4343ebf4dfb7799f"
+  integrity sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    has-symbols "^1.0.3"
     object-keys "^1.1.1"
 
 object.entries@^1.1.5:
@@ -970,7 +1307,7 @@ path-key@^3.1.0:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
-path-parse@^1.0.6:
+path-parse@^1.0.6, path-parse@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
@@ -1034,6 +1371,15 @@ regexp.prototype.flags@^1.3.1:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
 
+regexp.prototype.flags@^1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz#87cab30f80f66660181a3bb7bf5981a872b367ac"
+  integrity sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+    functions-have-names "^1.2.2"
+
 regexpp@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
@@ -1052,12 +1398,37 @@ resolve@^2.0.0-next.3:
     is-core-module "^2.2.0"
     path-parse "^1.0.6"
 
+resolve@^2.0.0-next.4:
+  version "2.0.0-next.4"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-2.0.0-next.4.tgz#3d37a113d6429f496ec4752d2a2e58efb1fd4660"
+  integrity sha512-iMDbmAWtfU+MHpxt/I5iWI7cY6YVEZUQ3MBgPQ++XD1PELuJHIl82xBmObyP2KyQmkNB2dsqF7seoQQiAn5yDQ==
+  dependencies:
+    is-core-module "^2.9.0"
+    path-parse "^1.0.7"
+    supports-preserve-symlinks-flag "^1.0.0"
+
+resumer@^0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/resumer/-/resumer-0.0.0.tgz#f1e8f461e4064ba39e82af3cdc2a8c893d076759"
+  integrity sha512-Fn9X8rX8yYF4m81rZCK/5VmrmsSbqS/i3rDLl6ZZHAXgC2nTAx3dhwG8q8odP/RmdLa2YrybDJaAMg+X1ajY3w==
+  dependencies:
+    through "~2.3.4"
+
 rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
+
+safe-regex-test@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/safe-regex-test/-/safe-regex-test-1.0.0.tgz#793b874d524eb3640d1873aad03596db2d4f2295"
+  integrity sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==
+  dependencies:
+    call-bind "^1.0.2"
+    get-intrinsic "^1.1.3"
+    is-regex "^1.1.4"
 
 scheduler@^0.20.2:
   version "0.20.2"
@@ -1100,6 +1471,13 @@ side-channel@^1.0.4:
     get-intrinsic "^1.0.2"
     object-inspect "^1.9.0"
 
+stop-iteration-iterator@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/stop-iteration-iterator/-/stop-iteration-iterator-1.0.0.tgz#6a60be0b4ee757d1ed5254858ec66b10c49285e4"
+  integrity sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==
+  dependencies:
+    internal-slot "^1.0.4"
+
 string.prototype.matchall@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/string.prototype.matchall/-/string.prototype.matchall-4.0.6.tgz#5abb5dabc94c7b0ea2380f65ba610b3a544b15fa"
@@ -1114,6 +1492,15 @@ string.prototype.matchall@^4.0.6:
     regexp.prototype.flags "^1.3.1"
     side-channel "^1.0.4"
 
+string.prototype.trim@^1.2.7:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/string.prototype.trim/-/string.prototype.trim-1.2.7.tgz#a68352740859f6893f14ce3ef1bb3037f7a90533"
+  integrity sha512-p6TmeT1T3411M8Cgg9wBTMRtY2q9+PNy9EV1i2lIXUN/btt763oIfxwN3RR8VU6wHX8j/1CFy0L+YuThm6bgOg==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    es-abstract "^1.20.4"
+
 string.prototype.trimend@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz#e75ae90c2942c63504686c18b287b4a0b1a45f80"
@@ -1122,6 +1509,15 @@ string.prototype.trimend@^1.0.4:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
 
+string.prototype.trimend@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz#c4a27fa026d979d79c04f17397f250a462944533"
+  integrity sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    es-abstract "^1.20.4"
+
 string.prototype.trimstart@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz#b36399af4ab2999b4c9c648bd7a3fb2bb26feeed"
@@ -1129,6 +1525,15 @@ string.prototype.trimstart@^1.0.4:
   dependencies:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
+
+string.prototype.trimstart@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.6.tgz#e90ab66aa8e4007d92ef591bbf3cd422c56bdcf4"
+  integrity sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    es-abstract "^1.20.4"
 
 strip-ansi@^6.0.1:
   version "6.0.1"
@@ -1149,10 +1554,47 @@ supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
+supports-preserve-symlinks-flag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
+  integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
+
+tape@^5.6.3:
+  version "5.6.3"
+  resolved "https://registry.yarnpkg.com/tape/-/tape-5.6.3.tgz#0d3cc82f96b0906f73b0981df1a38a44fec7901d"
+  integrity sha512-cUDDGSbyoSIpdUAqbqLI/r7i/S4BHuCB9M5j7E/LrLs/x/i4zeAJ798aqo+FGo+kr9seBZwr8AkZW6rjceyAMQ==
+  dependencies:
+    array.prototype.every "^1.1.4"
+    call-bind "^1.0.2"
+    deep-equal "^2.2.0"
+    defined "^1.0.1"
+    dotignore "^0.1.2"
+    for-each "^0.3.3"
+    get-package-type "^0.1.0"
+    glob "^7.2.3"
+    has "^1.0.3"
+    has-dynamic-import "^2.0.1"
+    inherits "^2.0.4"
+    is-regex "^1.1.4"
+    minimist "^1.2.7"
+    object-inspect "^1.12.3"
+    object-is "^1.1.5"
+    object-keys "^1.1.1"
+    object.assign "^4.1.4"
+    resolve "^2.0.0-next.4"
+    resumer "^0.0.0"
+    string.prototype.trim "^1.2.7"
+    through "^2.3.8"
+
 text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
+
+through@^2.3.8, through@~2.3.4:
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
+  integrity sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==
 
 tslib@^2.3.1:
   version "2.3.1"
@@ -1171,6 +1613,15 @@ type-fest@^0.20.2:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
   integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
 
+typed-array-length@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/typed-array-length/-/typed-array-length-1.0.4.tgz#89d83785e5c4098bec72e08b319651f0eac9c1bb"
+  integrity sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==
+  dependencies:
+    call-bind "^1.0.2"
+    for-each "^0.3.3"
+    is-typed-array "^1.1.9"
+
 unbox-primitive@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/unbox-primitive/-/unbox-primitive-1.0.1.tgz#085e215625ec3162574dc8859abee78a59b14471"
@@ -1179,6 +1630,16 @@ unbox-primitive@^1.0.1:
     function-bind "^1.1.1"
     has-bigints "^1.0.1"
     has-symbols "^1.0.2"
+    which-boxed-primitive "^1.0.2"
+
+unbox-primitive@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/unbox-primitive/-/unbox-primitive-1.0.2.tgz#29032021057d5e6cdbd08c5129c226dff8ed6f9e"
+  integrity sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==
+  dependencies:
+    call-bind "^1.0.2"
+    has-bigints "^1.0.2"
+    has-symbols "^1.0.3"
     which-boxed-primitive "^1.0.2"
 
 uri-js@^4.2.2:
@@ -1218,6 +1679,28 @@ which-boxed-primitive@^1.0.2:
     is-number-object "^1.0.4"
     is-string "^1.0.5"
     is-symbol "^1.0.3"
+
+which-collection@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/which-collection/-/which-collection-1.0.1.tgz#70eab71ebbbd2aefaf32f917082fc62cdcb70906"
+  integrity sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==
+  dependencies:
+    is-map "^2.0.1"
+    is-set "^2.0.1"
+    is-weakmap "^2.0.1"
+    is-weakset "^2.0.1"
+
+which-typed-array@^1.1.9:
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/which-typed-array/-/which-typed-array-1.1.9.tgz#307cf898025848cf995e795e8423c7f337efbde6"
+  integrity sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==
+  dependencies:
+    available-typed-arrays "^1.0.5"
+    call-bind "^1.0.2"
+    for-each "^0.3.3"
+    gopd "^1.0.1"
+    has-tostringtag "^1.0.0"
+    is-typed-array "^1.1.10"
 
 which@^2.0.1:
   version "2.0.2"


### PR DESCRIPTION
Edit: I have made the following updates to window.nostr:

```ts
getPublicKey (tweak : string) => string
/** 
* If no tweak argument is provided, works as normal.
* 
* If a tweak string is provided, returns the 
* tweaked public key.
*/
```

```ts
signEvent (
  event : NostrEvent,
  tweak : string
) => SignedEvent
/** 
* If no tweak argument is provided, works as normal.
* 
* If a tweak string is provided, returns an event 
* that is signed using the tweaked private key.
*/
```

```ts
getHmacKey (
  key : string, 
  fmt : 'SHA-256' | 'SHA-512'
) => string
/** 
* Optional, but I have included an API call 
* that returns a raw tweak that is deterministic,
* but does not include the private key.
*/
```

I have also included a test.html page which tests all endpoints. To use the testing tool, simply launch `test/test.html` using a web server or browser. Make sure that the private key embedded in test.html also matches the private key saved in your nos2x extention. (also make sure to backup your real private key)

My reason for adding these methods is that there are multiple cases where I need to either derive key material from the master private key, or otherwise generate key-pairs for signing. It would be nice if I could do this using the extension, so that the extension could retain custody of the master key (and ideally all derived keys). Otherwise I have to create these keys outside of the extension, in which case the extension becomes useless outside of protecting a single key.

I am using the native WebCrypto library for hmac signing, and the `@noble/secp256k1` library for basic private key tweaking (finite field addition).

All feedback is welcome.