### PR TITLE
adding 127.0.0.1 to resource list

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -28,7 +28,7 @@
   "web_accessible_resources": [
     {
       "resources": ["nostr-provider.js"],
-      "matches": ["https://*/*", "http://localhost:*/*"]
+      "matches": ["https://*/*", "http://localhost:*/*", "http://127.0.0.1:*/*"]
     }
   ]
 }


### PR DESCRIPTION
I attempted to run this extension with a web app I had running on localhost, but at `127.0.0.1`. The extension did not work since this address is not included in the `web_accessible_resources.matches` list. This PR adds the localhost IP address to that list.