### PR TITLE
Add NIP-26 delegation token signing function

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -7,6 +7,7 @@ import {
   nip19
 } from 'nostr-tools'
 import {encrypt, decrypt} from 'nostr-tools/nip04'
+import {createDelegation} from 'nostr-tools/nip26'
 import {Mutex} from 'async-mutex'
 
 import {
@@ -139,6 +140,10 @@ async function handleContentScriptMessage({type, params, host}) {
       case 'nip04.decrypt': {
         let {peer, ciphertext} = params
         return decrypt(sk, peer, ciphertext)
+      }
+      case 'nip26.createDelegation': {
+        let {parameters} = params
+        return createDelegation(sk, parameters)
       }
     }
   } catch (error) {

--- a/extension/nostr-provider.js
+++ b/extension/nostr-provider.js
@@ -26,6 +26,12 @@ window.nostr = {
     }
   },
 
+  nip26: {
+    async createDelegation(parameters) {
+      return window.nostr._call('nip26.createDelegation', {parameters})
+    },
+  },
+
   _call(type, params) {
     return new Promise((resolve, reject) => {
       let id = Math.random().toString().slice(4)


### PR DESCRIPTION
Exposing the `nostr-tools` `createDelegation` function so that the extension can sign a delegation token using its saved private key. The `parameters` arg is expected to have this type https://github.com/nbd-wtf/nostr-tools/blob/master/nip26.ts#L8
```
type Parameters = {
  pubkey: string // the key to whom the delegation will be given
  kind: number | undefined
  until: number | undefined // delegation will only be valid until this date
  since: number | undefined // delegation will be valid from this date on
}
```