### PR TITLE
fix(background): nostr-tools doesn't export nip04 file

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -6,7 +6,7 @@ import {
   getPublicKey,
   nip19
 } from 'nostr-tools'
-import {encrypt, decrypt} from 'nostr-tools/nip04'
+import {nip04} from 'nostr-tools'
 import {Mutex} from 'async-mutex'
 
 import {
@@ -15,6 +15,8 @@ import {
   readPermissionLevel,
   updatePermission
 } from './common'
+
+const {encrypt, decrypt} = nip04
 
 let openPrompt = null
 let promptMutex = new Mutex()


### PR DESCRIPTION
fix building issue

```shellshession
Error: Build failed with 1 error:
extension/background.js:9:31: ERROR: Could not resolve "nostr-tools/nip04"
```