### PR TITLE
Allow accessing window.nostr in frames

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -21,7 +21,8 @@
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
-      "js": ["content-script.build.js"]
+      "js": ["content-script.build.js"],
+      "all_frames": true
     }
   ],
   "permissions": ["storage"],


### PR DESCRIPTION
Currently if you have code in for example an iframe that tries to use NIP-07 it fails since `window.nostr` is not available even though the extension is installed. This is because of `all_frames: true` is missing in the manifest for the content script. I need this for a project I work on, so would be nice to get in. :) 

https://developer.chrome.com/docs/extensions/mv3/content_scripts/#frames

An other NIP-07 ext, Alby, already has this: https://github.com/getAlby/lightning-browser-extension/blob/a14c56ac317764af4203cb1b3e2afece0d77d3e8/src/manifest.json#L152