### PR TITLE
Inject content script faster with document_end

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -20,6 +20,7 @@
   },
   "content_scripts": [
     {
+      "run_at": "document_end",
       "matches": ["<all_urls>"],
       "js": ["content-script.build.js"],
       "all_frames": true


### PR DESCRIPTION
The default value for [run_at](https://developer.chrome.com/docs/extensions/reference/api/extensionTypes#type-RunAt) is `document_idle`, which injects the script at some random point of convenience after the page is loaded.

By setting it to `document_end`, it will inject the script immediately after the DOM is loaded, guaranteeing that window.nostr will be available as soon as the page loads.

This fixes problems with Ditto/Soapbox and nos2x (although I also [patched](https://gitlab.com/soapbox-pub/soapbox/-/merge_requests/3074) Soapbox to update the signer after it becomes available, making it more resilient to this problem).

Finally, it should be noted that Alby does it even faster https://github.com/getAlby/lightning-browser-extension/pull/2691 by using `document_start` and then doing a bunch of trickery in their content script to inject as soon as possible based on the browser and manifest version. While this is possible in nos2x, `document_end` is the ideal setting to keep things simple and still fix basically everything people complain about regarding NIP-07 loading.

I tested this locally and confirmed it works.