### PR TITLE
Enable support for .localhost tld domains

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -33,7 +33,7 @@
   "web_accessible_resources": [
     {
       "resources": ["nostr-provider.js"],
-      "matches": ["https://*/*", "http://localhost:*/*", "http://127.0.0.1:*/*"]
+      "matches": ["https://*/*", "http://localhost:*/*", "http://127.0.0.1:*/*", "http://*.localhost/*"]
     }
   ]
 }


### PR DESCRIPTION
I use a .localhost tld in development when working on many websites throughout the day, the extension was failing on these websites due to the nostr-provider.js script not being accessible, I've added a rule which will match .localhost domains

http://example.localhost
http://another.example.localhost/auth/login
etc...

Without this rule, `window.nostr` will not be available.

<img width="1536" alt="Screenshot 2024-08-02 at 17 37 03" src="https://github.com/user-attachments/assets/9ad6bed5-b5fb-45af-a787-381b9c76fd22">
