### PR TITLE
Deconstruct values of notification config from local storage of extension

### DIFF
--- a/extension/common.js
+++ b/extension/common.js
@@ -95,8 +95,8 @@ export async function removePermissions(host, accept, type) {
 }
 
 export async function showNotification(host, answer, type, params) {
-  let ok = await browser.storage.local.get('notifications')
-  if (ok) {
+  let {notifications} = await browser.storage.local.get('notifications')
+  if (notifications) {
     let action = answer ? 'allowed' : 'denied'
     browser.notifications.create(undefined, {
       type: 'basic',


### PR DESCRIPTION
We didn't deconstruct the values stored in the extension's local storage. This caused the L99 to always be evaluated as truthy (`!!{} == true`), resulting in the notifications always (annoyingly) being sent through the browser regardless of the configuration (checked or unchecked).

I simply added the process of deconstructing, the same as in other places.