### PR TITLE
Add build-on-push github action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,54 @@
+name: Build and Update Latest
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: github.event.head_commit.author.name != 'GitHub Action'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build Docker image
+        run: docker build -t nos2x-build .
+
+      - name: Run Docker container and extract nos2x.zip
+        run: |
+          docker create --name nos2x-container nos2x-build
+          docker start nos2x-container
+          docker cp nos2x-container:/app/nos2x.zip ./nos2x.zip
+          docker rm -f nos2x-container
+
+      - name: Verify nos2x.zip
+        run: |
+          ls -l nos2x.zip
+          md5sum nos2x.zip
+          file nos2x.zip
+
+      - name: Archive nos2x.zip
+        uses: actions/upload-artifact@v4
+        with:
+          name: nos2x-extension
+          path: nos2x.zip
+
+      - name: Get current date
+        id: date
+        run: echo "date=$(date +'%Y-%m-%d %H:%M:%S UTC')" >> $GITHUB_OUTPUT
+
+      - name: Update latest.md
+        run: |
+          echo "# Latest Build" > latest.md
+          echo "Last updated: ${{ steps.date.outputs.date }}" >> latest.md
+          echo "Download the latest build [here](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})" >> latest.md
+
+      - name: Commit and push latest.md
+        run: |
+          git config --global user.email "action@github.com"
+          git config --global user.name "GitHub Action"
+          git add latest.md
+          git commit -m "Update latest build link" || exit 0  # Exit gracefully if no changes
+          git push

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:18
+
+WORKDIR /app
+# Install zip and justfile
+RUN apt-get update && apt-get install -y zip
+RUN curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin
+
+
+COPY package.json ./
+RUN yarn install
+
+COPY . .
+
+RUN cat package.json
+RUN ls -la
+
+RUN just build
+RUN just package


### PR DESCRIPTION
This PR adds a `Dockerfile` for a container to to run `yarn` and package the extension both locally, without all the actual deps locally, and on Github actions.

The action also updates a md file to easily reach for the latest build.

Here you can see an example for the [action run](https://github.com/enigma/nos2x/actions/runs/10948502280) and [latest.md](https://github.com/enigma/nos2x/blob/master/latest.md)