### PR TITLE
Fix react misuse

### DIFF
--- a/extension/options.jsx
+++ b/extension/options.jsx
@@ -32,11 +32,17 @@ function Options() {
   let [scanning, setScanning] = useState(false)
   let [warningMessage, setWarningMessage] = useState('')
 
-  const showMessage = useCallback(msg => {
-    messages.push(msg)
-    setMessages(messages)
-    setTimeout(() => setMessages([]), 3000)
-  })
+  const showMessage = (msg) => {
+    setMessages((oldMessages) => [...oldMessages, msg])
+  }
+
+  useEffect(() => {
+    if (messages.length === 0) {
+      return
+    }
+    const timeout = setTimeout(() => setMessages([]), 3000)
+    return () => clearTimeout(timeout)
+  }, [messages, setMessages])
 
   useEffect(() => {
     browser.storage.local
@@ -647,11 +653,13 @@ function Options() {
 
   function addNewRelay() {
     if (newRelayURL.trim() === '') return
-    relays.push({
-      url: newRelayURL,
-      policy: { read: true, write: true }
-    })
-    setRelays(relays)
+    setRelays([
+      ...relays,
+      {
+        url: newRelayURL,
+        policy: { read: true, write: true }
+      },
+    ])
     addUnsavedChanges('relays')
     setNewRelayURL('')
   }
@@ -722,10 +730,7 @@ function Options() {
   }
 
   function addUnsavedChanges(section) {
-    if (!unsavedChanges.find(s => s === section)) {
-      unsavedChanges.push(section)
-      setUnsavedChanges(unsavedChanges)
-    }
+    setUnsavedChanges((currentUnsavedChanges) => currentUnsavedChanges.includes(section) ? currentUnsavedChanges : [...currentUnsavedChanges, section])
   }
 
   async function saveChanges() {


### PR DESCRIPTION
`showMessage` should not leave running timeouts in the background, and should pass a mutation-function to `setMessages` so in can be used multiple times in a row.

Also, when mutating state of arrays, the old arrays should not be changed because it might prevent `useEffect`s from detecting the change.