### PR TITLE
Fix unhandled errors

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -202,11 +202,11 @@ async function performOperation(type, params) {
       }
       case 'nip04.encrypt': {
         let {peer, plaintext} = params
-        return nip04.encrypt(sk, peer, plaintext)
+        return await nip04.encrypt(sk, peer, plaintext)
       }
       case 'nip04.decrypt': {
         let {peer, ciphertext} = params
-        return nip04.decrypt(sk, peer, ciphertext)
+        return await nip04.decrypt(sk, peer, ciphertext)
       }
       case 'nip44.encrypt': {
         const {peer, plaintext} = params


### PR DESCRIPTION
Fixed a failure to catch an exception (like decrypting an empty string) that was occurring from a6b66b206c2ddd2b51871f729a5588e4e8c1a0a8.
I've tested it here: https://svelte-5.pages.dev/nos2x