### PR TITLE
Add NIP-60 signSecret support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ async window.nostr.nip04.encrypt(pubkey, plaintext): string // returns ciphertex
 async window.nostr.nip04.decrypt(pubkey, ciphertext): string // takes ciphertext+iv as specified in nip04
 async window.nostr.nip44.encrypt(pubkey, plaintext): string // takes pubkey, plaintext, returns ciphertext as specified in nip-44
 async window.nostr.nip44.decrypt(pubkey, ciphertext): string // takes pubkey, ciphertext, returns plaintext as specified in nip-44
+async window.nostr.nip60.signSecret(proof_secret): { hash: string, sig: string, pubkey: string } // as specified in nip-60
 ```
 
 This extension is Chromium-only. For a maintained Firefox fork, see [nos2x-fox](https://diegogurpegui.com/nos2x-fox/).

--- a/extension/common.js
+++ b/extension/common.js
@@ -10,7 +10,8 @@ export const PERMISSION_NAMES = Object.fromEntries([
   ['nip04.encrypt', 'encrypt messages to peers'],
   ['nip04.decrypt', 'decrypt messages from peers'],
   ['nip44.encrypt', 'encrypt messages to peers'],
-  ['nip44.decrypt', 'decrypt messages from peers']
+  ['nip44.decrypt', 'decrypt messages from peers'],
+  ['nip60.signSecret', 'sign cashu secrets using your private key'],
 ])
 
 function matchConditions(conditions, event) {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "nos2x",
   "description": "Nostr Signer Extension",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "homepage_url": "https://github.com/fiatjaf/nos2x",
   "manifest_version": 3,
   "icons": {

--- a/extension/nostr-provider.js
+++ b/extension/nostr-provider.js
@@ -36,6 +36,12 @@ window.nostr = {
     }
   },
 
+  nip60: {
+    async signSecret(secret) {
+      return window.nostr._call('nip60.signSecret', {secret})
+    },
+  },
+
   _call(type, params) {
     let id = Math.random().toString().slice(-4)
     console.log(


### PR DESCRIPTION
Adds optional nip60.signSecret() support as specified in https://github.com/nostr-protocol/nips/pull/1890